### PR TITLE
Remove calls to lifemap-back from vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@ _pkgdown.yml
 ^\.github$
 .lintr
 ^codemeta\.json$
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ LifemapR.Rproj
 .RData
 .Ruserdata
 R/.Rhistory
+.vscode/
+test.R

--- a/R/display_map.R
+++ b/R/display_map.R
@@ -10,9 +10,7 @@
 #' @export
 #' @importFrom leaflet leaflet addTiles providerTileOptions
 #' @importFrom RCurl url.exists
-#'
-#' @examples
-#' display_map()
+
 display_map <- function(df = NULL, basemap = NULL) {
   if (!is.null(basemap)) {
     warning("The basemap argument is now deprecated.")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # LifemapR <img src="man/figures/lifemapr-logo.png" align="right" style="float:right; width:20%;"/>
 
-An R package to visualise data on a Lifemap base (https://lifemap-ncbi.univ-lyon1.fr/)
+An R package to visualise data on a Lifemap base (https://lifemap.cnrs.fr/)
 
 ## Installation
 

--- a/vignettes/runLifemapR.Rmd
+++ b/vignettes/runLifemapR.Rmd
@@ -47,16 +47,13 @@ require("LifemapR")
 
 The very first step to use this package is to have a dataframe containing at least a ```taxid``` column containing NCBI format TaxIds. This dataframe can also contain other data that you might want to visualise.
 
-```{r buildLF, eval = TRUE, echo = FALSE, results = FALSE, warning = FALSE}
-require("LifemapR", quietly = TRUE)
-
-data(eukaryotes_1000)
-LM_eukaryotes <- build_Lifemap(eukaryotes_1000)
 ```
-
-```{r printLF, eval = TRUE, echo = FALSE}
-if (is.lifemap_obj(LM_eukaryotes))
-  LM_eukaryotes$df[6:10, 1:5]
+##      taxid                            sci_name zoom        lat        lon
+## 6  1003877                         Benincaseae   20  9.3052589  -7.025261
+## 7  1004254         Cyberlindnera subsufficiens   24  6.3197736 -10.573859
+## 8  1008252                             Melinae   25 -0.9776037 -12.991050
+## 9   100860                         Aphanomyces   17 -7.8904607 -12.002383
+## 10  100903 Fusarium oxysporum f. sp. fragariae   32  6.2603410 -11.277101
 ```
 
 You can then transform this dataframe into a format suitable for the visualisation functions of the package with the ```build_Lifemap``` function.\


### PR DESCRIPTION
Remove calls to lifemap-back from the vignette to avoid CRAN check errors when the backend is down.